### PR TITLE
feat: add dropdown and A-or-B question blocks

### DIFF
--- a/src/features/activities/components/BlockRenderer.tsx
+++ b/src/features/activities/components/BlockRenderer.tsx
@@ -33,6 +33,8 @@ case 'media':
 case 'question':
 case 'text_input':
 case 'multiple_choice':
+case 'dropdown_input':
+case 'a_or_b_input':
   return (
     <QuestionBlock
       config={block.config as any}

--- a/src/features/activities/components/blocks/QuestionBlock.tsx
+++ b/src/features/activities/components/blocks/QuestionBlock.tsx
@@ -1,6 +1,15 @@
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useTheme } from '../../../../styles';
-import { QuestionBlockConfig, MultipleChoiceOption, MultipleChoiceConfig, TextInputConfig } from '../../types';
+import {
+  QuestionBlockConfig,
+  MultipleChoiceOption,
+  MultipleChoiceConfig,
+  TextInputConfig,
+  DropdownInputConfig,
+  AorBInputConfig,
+  AorBPrompt,
+} from '../../types';
+import { Button } from '../../../../shared/components';
 
 export interface QuestionBlockProps {
   config: QuestionBlockConfig;
@@ -14,11 +23,102 @@ export const QuestionBlock: React.FC<QuestionBlockProps> = ({
   initialValue
 }) => {
   const { colors, tokens } = useTheme();
-  const [value, setValue] = useState(initialValue || null);
+  const defaultValueForType = useMemo(() => {
+    switch (config.question_type) {
+      case 'multiple_choice':
+      case 'single_choice':
+        return [];
+      case 'text_input':
+      case 'dropdown_input':
+        return '';
+      case 'a_or_b_input':
+        return {};
+      default:
+        return null;
+    }
+  }, [config.question_type]);
+
+  const [value, setValue] = useState<any>(() => {
+    if (initialValue !== undefined) {
+      return initialValue ?? defaultValueForType;
+    }
+    return defaultValueForType;
+  });
+
+  const [aOrBIndex, setAOrBIndex] = useState(0);
+  const [aOrBAnimationState, setAOrBAnimationState] = useState<'idle' | 'exiting' | 'entering'>('idle');
+  const [aOrBDirection, setAOrBDirection] = useState<'forward' | 'backward'>('forward');
+  const exitTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const enterTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const aOrBPrompts = useMemo<AorBPrompt[]>(() => {
+    if (config.question_type !== 'a_or_b_input') {
+      return [];
+    }
+    const baseConfig = (config.config || {}) as AorBInputConfig;
+    return baseConfig.prompts || (baseConfig as any).options || [];
+  }, [config]);
+
+  useEffect(() => {
+    if (initialValue !== undefined) {
+      setValue(initialValue ?? defaultValueForType);
+    }
+  }, [initialValue, defaultValueForType]);
+
+  useEffect(() => {
+    return () => {
+      if (exitTimeoutRef.current) {
+        clearTimeout(exitTimeoutRef.current);
+      }
+      if (enterTimeoutRef.current) {
+        clearTimeout(enterTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (config.question_type !== 'a_or_b_input') {
+      if (aOrBIndex !== 0) {
+        setAOrBIndex(0);
+      }
+      return;
+    }
+
+    if (aOrBPrompts.length === 0 && aOrBIndex !== 0) {
+      setAOrBIndex(0);
+    } else if (aOrBPrompts.length > 0 && aOrBIndex >= aOrBPrompts.length) {
+      setAOrBIndex(aOrBPrompts.length - 1);
+    }
+  }, [config.question_type, aOrBPrompts, aOrBIndex]);
 
   const handleChange = (newValue: any) => {
     setValue(newValue);
     onResponseChange?.(config.question_id, newValue);
+  };
+
+  const transitionToIndex = (nextIndex: number, direction: 'forward' | 'backward') => {
+    if (nextIndex < 0 || nextIndex >= aOrBPrompts.length) {
+      return;
+    }
+
+    if (exitTimeoutRef.current) {
+      clearTimeout(exitTimeoutRef.current);
+    }
+    if (enterTimeoutRef.current) {
+      clearTimeout(enterTimeoutRef.current);
+    }
+
+    setAOrBDirection(direction);
+    setAOrBAnimationState('exiting');
+
+    exitTimeoutRef.current = setTimeout(() => {
+      setAOrBIndex(nextIndex);
+      setAOrBAnimationState('entering');
+
+      enterTimeoutRef.current = setTimeout(() => {
+        setAOrBAnimationState('idle');
+      }, 200);
+    }, 200);
   };
 
   const getContainerStyle = () => ({
@@ -49,7 +149,11 @@ export const QuestionBlock: React.FC<QuestionBlockProps> = ({
   });
 
   const renderMultipleChoice = (questionConfig: MultipleChoiceConfig) => {
-    const selectedIds = value || [];
+    const selectedIds = Array.isArray(value)
+      ? value
+      : typeof value === 'string'
+        ? [value]
+        : [];
     // Handle both nested config and flat config from backend
     const options = questionConfig?.options || config.options || [];
     const maxSelect = questionConfig?.max_select || config.max_select || 1;
@@ -140,6 +244,7 @@ export const QuestionBlock: React.FC<QuestionBlockProps> = ({
     const multiline = questionConfig?.multiline || config.multiline || false;
     const maxLength = questionConfig?.max_length || config.max_length;
     const placeholder = questionConfig?.placeholder || config.placeholder || '';
+    const textValue = typeof value === 'string' ? value : '';
 
     const inputStyle = {
       width: '100%',
@@ -154,7 +259,7 @@ export const QuestionBlock: React.FC<QuestionBlockProps> = ({
       minHeight: multiline ? '100px' : 'auto',
     };
 
-    const currentLength = value?.length || 0;
+    const currentLength = textValue.length;
 
     const counterStyle = {
       ...tokens.typography.body.small,
@@ -167,7 +272,7 @@ export const QuestionBlock: React.FC<QuestionBlockProps> = ({
       return (
         <div>
           <textarea
-            value={value || ''}
+            value={textValue}
             onChange={(e) => handleChange(e.target.value)}
             placeholder={placeholder}
             maxLength={maxLength}
@@ -185,7 +290,7 @@ export const QuestionBlock: React.FC<QuestionBlockProps> = ({
         <div>
           <input
             type="text"
-            value={value || ''}
+            value={textValue}
             onChange={(e) => handleChange(e.target.value)}
             placeholder={placeholder}
             maxLength={maxLength}
@@ -201,6 +306,183 @@ export const QuestionBlock: React.FC<QuestionBlockProps> = ({
     }
   };
 
+  const renderDropdown = (questionConfig: DropdownInputConfig) => {
+    const options = questionConfig?.options || (config as any).options || [];
+    const placeholder = questionConfig?.placeholder || (config as any).placeholder || 'Select an option...';
+    const selectedValue = typeof value === 'string' ? value : '';
+
+    const selectStyle = {
+      width: '100%',
+      padding: tokens.spacing[3],
+      backgroundColor: colors.surface,
+      border: `1px solid ${colors.outline}`,
+      borderRadius: tokens.borderRadius.medium,
+      color: selectedValue ? colors.onSurface : colors.onSurfaceVariant,
+      fontSize: tokens.typography.body.medium.fontSize,
+      fontFamily: tokens.typography.body.medium.fontFamily,
+      outline: 'none',
+    };
+
+    const helperTextStyle = {
+      ...tokens.typography.body.small,
+      color: colors.onSurfaceVariant,
+      marginTop: tokens.spacing[2],
+    };
+
+    return (
+      <div>
+        <select
+          value={selectedValue}
+          onChange={(e) => handleChange(e.target.value)}
+          style={selectStyle}
+        >
+          <option value="">{placeholder}</option>
+          {options.map((option: MultipleChoiceOption) => (
+            <option key={option.id} value={option.id}>
+              {option.title || (option as any).label || 'Untitled option'}
+            </option>
+          ))}
+        </select>
+        {options.length === 0 && (
+          <div style={helperTextStyle}>
+            Add options to this dropdown to collect a response.
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  const renderAorB = (questionConfig: AorBInputConfig) => {
+    const prompts = aOrBPrompts;
+    const answers = value && typeof value === 'object' && !Array.isArray(value)
+      ? (value as Record<string, boolean>)
+      : {};
+
+    if (prompts.length === 0) {
+      return (
+        <div
+          style={{
+            ...tokens.typography.body.small,
+            color: colors.onSurfaceVariant,
+          }}
+        >
+          Add prompts to configure this A or B sequence.
+        </div>
+      );
+    }
+
+    const currentPrompt = prompts[aOrBIndex];
+    const progressText = `Prompt ${Math.min(aOrBIndex + 1, prompts.length)} of ${prompts.length}`;
+    const currentAnswer = currentPrompt ? answers[currentPrompt.id] : undefined;
+    const yesLabel = questionConfig?.positive_label || 'Yes';
+    const noLabel = questionConfig?.negative_label || 'No';
+
+    const getAnimationTransform = () => {
+      if (aOrBAnimationState === 'idle') return 'translateX(0)';
+      if (aOrBAnimationState === 'exiting') {
+        return aOrBDirection === 'forward' ? 'translateX(-12px)' : 'translateX(12px)';
+      }
+      if (aOrBAnimationState === 'entering') {
+        return aOrBDirection === 'forward' ? 'translateX(12px)' : 'translateX(-12px)';
+      }
+      return 'translateX(0)';
+    };
+
+    const cardStyle = {
+      padding: tokens.spacing[4],
+      borderRadius: tokens.borderRadius.medium,
+      border: `1px solid ${colors.outline}`,
+      backgroundColor: colors.surface,
+      minHeight: '160px',
+      display: 'flex',
+      flexDirection: 'column' as const,
+      gap: tokens.spacing[2],
+      transition: 'opacity 0.25s ease, transform 0.25s ease',
+      opacity: aOrBAnimationState === 'exiting' ? 0 : 1,
+      transform: getAnimationTransform(),
+    };
+
+    const promptTitleStyle = {
+      ...tokens.typography.title.small,
+      color: colors.onSurface,
+      margin: 0,
+    };
+
+    const promptBodyStyle = {
+      ...tokens.typography.body.medium,
+      color: colors.onSurfaceVariant,
+      margin: 0,
+    };
+
+    const progressStyle = {
+      ...tokens.typography.label.small,
+      color: colors.onSurfaceVariant,
+    };
+
+    const buttonRowStyle = {
+      display: 'flex',
+      gap: tokens.spacing[2],
+      marginTop: tokens.spacing[3],
+      flexWrap: 'wrap' as const,
+    };
+
+    const handleAnswer = (decision: boolean) => {
+      if (!currentPrompt) return;
+      const updatedAnswers = {
+        ...answers,
+        [currentPrompt.id]: decision,
+      };
+      handleChange(updatedAnswers);
+
+      if (aOrBIndex < prompts.length - 1) {
+        transitionToIndex(aOrBIndex + 1, 'forward');
+      }
+    };
+
+    const handleBack = () => {
+      if (aOrBIndex === 0) return;
+      transitionToIndex(aOrBIndex - 1, 'backward');
+    };
+
+    return (
+      <div>
+        <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: tokens.spacing[2] }}>
+          <span style={progressStyle}>{progressText}</span>
+          <span style={progressStyle}>
+            {Object.keys(answers).length}/{prompts.length} answered
+          </span>
+        </div>
+        <div style={cardStyle}>
+          <h4 style={promptTitleStyle}>{currentPrompt?.title}</h4>
+          {currentPrompt?.description && (
+            <p style={promptBodyStyle}>{currentPrompt.description}</p>
+          )}
+        </div>
+        <div style={buttonRowStyle}>
+          <Button
+            variant={currentAnswer === true ? 'filled' : 'outlined'}
+            onClick={() => handleAnswer(true)}
+          >
+            {yesLabel}
+          </Button>
+          <Button
+            variant={currentAnswer === false ? 'filled' : 'outlined'}
+            onClick={() => handleAnswer(false)}
+          >
+            {noLabel}
+          </Button>
+          <Button
+            variant="text"
+            onClick={handleBack}
+            disabled={aOrBIndex === 0}
+          >
+            Back
+          </Button>
+        </div>
+      </div>
+    );
+  };
+
   const renderQuestionContent = () => {
     switch (config.question_type) {
       case 'multiple_choice':
@@ -208,6 +490,10 @@ export const QuestionBlock: React.FC<QuestionBlockProps> = ({
         return renderMultipleChoice((config.config || {}) as MultipleChoiceConfig);
       case 'text_input':
         return renderTextInput((config.config || {}) as TextInputConfig);
+      case 'dropdown_input':
+        return renderDropdown((config.config || {}) as DropdownInputConfig);
+      case 'a_or_b_input':
+        return renderAorB((config.config || {}) as AorBInputConfig);
       default:
         return (
           <div style={{

--- a/src/features/activities/types/index.ts
+++ b/src/features/activities/types/index.ts
@@ -80,6 +80,23 @@ export interface TextInputConfig {
   multiline?: boolean;
 }
 
+export interface DropdownInputConfig {
+  placeholder?: string;
+  options: MultipleChoiceOption[];
+}
+
+export interface AorBPrompt {
+  id: string;
+  title: string;
+  description?: string;
+}
+
+export interface AorBInputConfig {
+  prompts: AorBPrompt[];
+  positive_label?: string;
+  negative_label?: string;
+}
+
 // Block Type Configs
 export interface TextBlockConfig {
   style: 'h1' | 'h2' | 'h3' | 'body' | 'lead' | 'quote';
@@ -97,12 +114,12 @@ export interface MediaBlockConfig {
 
 export interface QuestionBlockConfig {
   question_id: string;
-  question_type: 'multiple_choice' | 'text_input' | 'single_choice';
+  question_type: 'multiple_choice' | 'text_input' | 'single_choice' | 'dropdown_input' | 'a_or_b_input';
   title: string;
   subtitle?: string;
   tooltip?: string;
   required: boolean;
-  config: MultipleChoiceConfig | TextInputConfig | Record<string, any>;
+  config: MultipleChoiceConfig | TextInputConfig | DropdownInputConfig | AorBInputConfig | Record<string, any>;
 }
 
 // Attempt and Response Types

--- a/src/features/admin/components/ActivityPageCard.tsx
+++ b/src/features/admin/components/ActivityPageCard.tsx
@@ -110,6 +110,40 @@ export const ActivityPageCard: React.FC<ActivityPageCardProps> = ({
     return media.find(m => m.media_id === mediaId);
   };
 
+  const renderQuestionSummary = (block: Block) => {
+    const questionConfig = block.config || {};
+    const displayType = questionConfig.question_type || block.block_type;
+    const nestedConfig = questionConfig.config || {};
+    const options = questionConfig.options || nestedConfig.options || [];
+    const prompts = questionConfig.prompts || nestedConfig.prompts || [];
+
+    return (
+      <div style={styles.questionContainer}>
+        <div style={styles.questionTitle}>
+          {questionConfig.title || questionConfig.question_text || 'Question'}
+        </div>
+        {questionConfig.subtitle && (
+          <div style={styles.questionSubtitle}>
+            {questionConfig.subtitle}
+          </div>
+        )}
+        <div style={{ ...styles.blockContent, marginTop: tokens.spacing[2], fontSize: '14px' }}>
+          Type: {displayType || 'Unknown'}{questionConfig.required && ' (Required)'}
+        </div>
+        {['multiple_choice', 'single_choice', 'dropdown_input'].includes(displayType) && options.length > 0 && (
+          <div style={{ ...styles.blockContent, marginTop: tokens.spacing[2], fontSize: '12px' }}>
+            Options: {options.map((opt: any) => opt.title || opt.label).join(', ')}
+          </div>
+        )}
+        {displayType === 'a_or_b_input' && prompts.length > 0 && (
+          <div style={{ ...styles.blockContent, marginTop: tokens.spacing[2], fontSize: '12px' }}>
+            Prompts: {prompts.map((prompt: any) => prompt.title).join(', ')}
+          </div>
+        )}
+      </div>
+    );
+  };
+
   const renderBlockContent = (block: Block) => {
     switch (block.block_type) {
       case 'text':
@@ -139,27 +173,11 @@ export const ActivityPageCard: React.FC<ActivityPageCardProps> = ({
         );
 
       case 'question':
-        return (
-          <div style={styles.questionContainer}>
-            <div style={styles.questionTitle}>
-              {block.config.title || block.config.question_text || 'Question'}
-            </div>
-            {block.config.subtitle && (
-              <div style={styles.questionSubtitle}>
-                {block.config.subtitle}
-              </div>
-            )}
-            <div style={{ ...styles.blockContent, marginTop: tokens.spacing[2], fontSize: '14px' }}>
-              Type: {block.config.question_type || 'Unknown'}
-              {block.config.required && ' (Required)'}
-            </div>
-            {block.config.options && (
-              <div style={{ ...styles.blockContent, marginTop: tokens.spacing[2], fontSize: '12px' }}>
-                Options: {block.config.options.map((opt: any) => opt.title || opt.label).join(', ')}
-              </div>
-            )}
-          </div>
-        );
+      case 'text_input':
+      case 'multiple_choice':
+      case 'dropdown_input':
+      case 'a_or_b_input':
+        return renderQuestionSummary(block);
 
       default:
         return (

--- a/src/features/admin/components/EditableAorBInputBlock.tsx
+++ b/src/features/admin/components/EditableAorBInputBlock.tsx
@@ -1,0 +1,259 @@
+import React from 'react';
+import { useTheme } from '../../../styles';
+import { Button, IconButton } from '../../../shared/components';
+import { AorBInputConfig, AorBPrompt, QuestionBlockConfig } from '../../activities/types';
+
+export interface EditableAorBInputBlockProps {
+  config: QuestionBlockConfig;
+  onChange: (updatedConfig: QuestionBlockConfig) => void;
+}
+
+export const EditableAorBInputBlock: React.FC<EditableAorBInputBlockProps> = ({
+  config,
+  onChange
+}) => {
+  const { colors, tokens } = useTheme();
+
+  const aOrBConfig = (config.config || {}) as AorBInputConfig;
+  const prompts = (aOrBConfig.prompts || (config as any).prompts || []) as AorBPrompt[];
+  const positiveLabel = aOrBConfig.positive_label ?? 'Yes';
+  const negativeLabel = aOrBConfig.negative_label ?? 'No';
+
+  const getStyles = () => ({
+    container: {
+      border: `2px solid ${colors.outline}`,
+      borderRadius: tokens.borderRadius.medium,
+      padding: tokens.spacing[4],
+      backgroundColor: colors.surfaceContainerLow,
+    },
+    header: {
+      marginBottom: tokens.spacing[4],
+    },
+    label: {
+      ...tokens.typography.label.small,
+      color: colors.onSurfaceVariant,
+      marginBottom: tokens.spacing[2],
+    },
+    input: {
+      ...tokens.typography.body.medium,
+      width: '100%',
+      padding: tokens.spacing[3],
+      border: `1px solid ${colors.outline}`,
+      borderRadius: tokens.borderRadius.small,
+      backgroundColor: colors.surface,
+      color: colors.onSurface,
+      outline: 'none',
+      fontFamily: 'inherit',
+    },
+    textarea: {
+      ...tokens.typography.body.medium,
+      width: '100%',
+      minHeight: '72px',
+      padding: tokens.spacing[3],
+      border: `1px solid ${colors.outline}`,
+      borderRadius: tokens.borderRadius.small,
+      backgroundColor: colors.surface,
+      color: colors.onSurface,
+      outline: 'none',
+      fontFamily: 'inherit',
+      resize: 'vertical' as const,
+    },
+    checkbox: {
+      display: 'flex',
+      alignItems: 'center',
+      gap: tokens.spacing[2],
+      marginTop: tokens.spacing[3],
+    },
+    checkboxInput: {
+      width: '18px',
+      height: '18px',
+      cursor: 'pointer',
+    },
+    checkboxLabel: {
+      ...tokens.typography.body.medium,
+      color: colors.onSurface,
+      cursor: 'pointer',
+    },
+    promptRow: {
+      border: `1px solid ${colors.outline}`,
+      borderRadius: tokens.borderRadius.medium,
+      padding: tokens.spacing[3],
+      backgroundColor: colors.surface,
+      display: 'flex',
+      flexDirection: 'column' as const,
+      gap: tokens.spacing[2],
+    },
+    promptHeader: {
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      color: colors.onSurfaceVariant,
+      ...tokens.typography.label.small,
+    },
+    promptList: {
+      display: 'flex',
+      flexDirection: 'column' as const,
+      gap: tokens.spacing[3],
+    },
+  });
+
+  const styles = getStyles();
+
+  const handleChange = (field: keyof QuestionBlockConfig, value: any) => {
+    onChange({
+      ...config,
+      [field]: value,
+    });
+  };
+
+  const handleConfigChange = (field: keyof AorBInputConfig, value: any) => {
+    onChange({
+      ...config,
+      config: {
+        ...aOrBConfig,
+        [field]: value,
+      },
+    });
+  };
+
+  const handleAddPrompt = () => {
+    const newPrompt: AorBPrompt = {
+      id: `prompt_${Date.now()}`,
+      title: 'New statement',
+      description: '',
+    };
+    handleConfigChange('prompts', [...prompts, newPrompt]);
+  };
+
+  const handleUpdatePrompt = (
+    index: number,
+    field: keyof AorBPrompt,
+    value: string
+  ) => {
+    const updatedPrompts = [...prompts];
+    updatedPrompts[index] = {
+      ...updatedPrompts[index],
+      [field]: value,
+    };
+    handleConfigChange('prompts', updatedPrompts);
+  };
+
+  const handleDeletePrompt = (index: number) => {
+    const updatedPrompts = prompts.filter((_, i) => i !== index);
+    handleConfigChange('prompts', updatedPrompts);
+  };
+
+  return (
+    <div style={styles.container}>
+      <div style={styles.header}>
+        <span
+          style={{
+            ...tokens.typography.label.large,
+            color: colors.primary,
+          }}
+        >
+          A or B Question
+        </span>
+      </div>
+
+      <div style={{ marginBottom: tokens.spacing[3] }}>
+        <label style={styles.label}>Question Title *</label>
+        <input
+          type="text"
+          value={config.title || ''}
+          onChange={(e) => handleChange('title', e.target.value)}
+          placeholder="Introduce your sequence..."
+          style={styles.input}
+        />
+      </div>
+
+      <div style={{ marginBottom: tokens.spacing[3] }}>
+        <label style={styles.label}>Subtitle (optional)</label>
+        <input
+          type="text"
+          value={config.subtitle || ''}
+          onChange={(e) => handleChange('subtitle', e.target.value)}
+          placeholder="Explain how the responses should be used..."
+          style={styles.input}
+        />
+      </div>
+
+      <div style={{ display: 'flex', gap: tokens.spacing[3], marginBottom: tokens.spacing[3] }}>
+        <div style={{ flex: 1 }}>
+          <label style={styles.label}>Positive button label</label>
+          <input
+            type="text"
+            value={positiveLabel}
+            onChange={(e) => handleConfigChange('positive_label', e.target.value)}
+            placeholder="Yes"
+            style={styles.input}
+          />
+        </div>
+        <div style={{ flex: 1 }}>
+          <label style={styles.label}>Negative button label</label>
+          <input
+            type="text"
+            value={negativeLabel}
+            onChange={(e) => handleConfigChange('negative_label', e.target.value)}
+            placeholder="No"
+            style={styles.input}
+          />
+        </div>
+      </div>
+
+      <div style={{ marginBottom: tokens.spacing[2] }}>
+        <label style={styles.label}>Prompts</label>
+      </div>
+
+      <div style={styles.promptList}>
+        {prompts.map((prompt, index) => (
+          <div key={prompt.id} style={styles.promptRow}>
+            <div style={styles.promptHeader}>
+              <span>Prompt {index + 1}</span>
+              <IconButton
+                icon="delete"
+                variant="text"
+                onClick={() => handleDeletePrompt(index)}
+                title="Remove prompt"
+              />
+            </div>
+            <input
+              type="text"
+              value={prompt.title}
+              onChange={(e) => handleUpdatePrompt(index, 'title', e.target.value)}
+              placeholder="Prompt question or statement"
+              style={styles.input}
+            />
+            <textarea
+              value={prompt.description || ''}
+              onChange={(e) => handleUpdatePrompt(index, 'description', e.target.value)}
+              placeholder="Optional supporting detail"
+              style={styles.textarea}
+            />
+          </div>
+        ))}
+      </div>
+
+      <Button
+        variant="outlined"
+        onClick={handleAddPrompt}
+        style={{ marginTop: tokens.spacing[2] }}
+      >
+        + Add Prompt
+      </Button>
+
+      <div style={styles.checkbox}>
+        <input
+          type="checkbox"
+          id={`required-aorb-${config.question_id}`}
+          checked={config.required || false}
+          onChange={(e) => handleChange('required', e.target.checked)}
+          style={styles.checkboxInput}
+        />
+        <label htmlFor={`required-aorb-${config.question_id}`} style={styles.checkboxLabel}>
+          Required
+        </label>
+      </div>
+    </div>
+  );
+};

--- a/src/features/admin/components/EditableBlockRenderer.tsx
+++ b/src/features/admin/components/EditableBlockRenderer.tsx
@@ -5,6 +5,8 @@ import { EditableTextBlock } from './EditableTextBlock';
 import { EditableMediaBlock } from './EditableMediaBlock';
 import { EditableTextInputBlock } from './EditableTextInputBlock';
 import { EditableMultipleChoiceBlock } from './EditableMultipleChoiceBlock';
+import { EditableDropdownInputBlock } from './EditableDropdownInputBlock';
+import { EditableAorBInputBlock } from './EditableAorBInputBlock';
 export interface EditableBlockRendererProps {
   block: Block;
   media: MediaAsset[];
@@ -60,6 +62,22 @@ export const EditableBlockRenderer: React.FC<EditableBlockRendererProps> = ({
       case 'multiple_choice':
         return (
           <EditableMultipleChoiceBlock
+            config={block.config as any}
+            onChange={handleConfigChange}
+          />
+        );
+
+      case 'dropdown_input':
+        return (
+          <EditableDropdownInputBlock
+            config={block.config as any}
+            onChange={handleConfigChange}
+          />
+        );
+
+      case 'a_or_b_input':
+        return (
+          <EditableAorBInputBlock
             config={block.config as any}
             onChange={handleConfigChange}
           />

--- a/src/features/admin/components/EditableDropdownInputBlock.tsx
+++ b/src/features/admin/components/EditableDropdownInputBlock.tsx
@@ -1,0 +1,233 @@
+import React from 'react';
+import { useTheme } from '../../../styles';
+import { Button, IconButton } from '../../../shared/components';
+import { DropdownInputConfig, MultipleChoiceOption, QuestionBlockConfig } from '../../activities/types';
+
+export interface EditableDropdownInputBlockProps {
+  config: QuestionBlockConfig;
+  onChange: (updatedConfig: QuestionBlockConfig) => void;
+}
+
+export const EditableDropdownInputBlock: React.FC<EditableDropdownInputBlockProps> = ({
+  config,
+  onChange
+}) => {
+  const { colors, tokens } = useTheme();
+
+  const dropdownConfig = (config.config || {}) as DropdownInputConfig;
+  const options = (dropdownConfig.options || (config as any).options || []) as MultipleChoiceOption[];
+  const placeholder = dropdownConfig.placeholder ?? '';
+
+  const getStyles = () => ({
+    container: {
+      border: `2px solid ${colors.outline}`,
+      borderRadius: tokens.borderRadius.medium,
+      padding: tokens.spacing[4],
+      backgroundColor: colors.surfaceContainerLow,
+    },
+    header: {
+      marginBottom: tokens.spacing[4],
+    },
+    label: {
+      ...tokens.typography.label.small,
+      color: colors.onSurfaceVariant,
+      marginBottom: tokens.spacing[2],
+    },
+    input: {
+      ...tokens.typography.body.medium,
+      width: '100%',
+      padding: tokens.spacing[3],
+      border: `1px solid ${colors.outline}`,
+      borderRadius: tokens.borderRadius.small,
+      backgroundColor: colors.surface,
+      color: colors.onSurface,
+      outline: 'none',
+      fontFamily: 'inherit',
+    },
+    checkbox: {
+      display: 'flex',
+      alignItems: 'center',
+      gap: tokens.spacing[2],
+      marginTop: tokens.spacing[3],
+    },
+    checkboxInput: {
+      width: '18px',
+      height: '18px',
+      cursor: 'pointer',
+    },
+    checkboxLabel: {
+      ...tokens.typography.body.medium,
+      color: colors.onSurface,
+      cursor: 'pointer',
+    },
+    optionRow: {
+      display: 'flex',
+      alignItems: 'center',
+      gap: tokens.spacing[2],
+      marginBottom: tokens.spacing[2],
+    },
+    optionIndex: {
+      ...tokens.typography.body.medium,
+      color: colors.onSurfaceVariant,
+      minWidth: '20px',
+      textAlign: 'right' as const,
+    },
+    selectPreview: {
+      ...tokens.typography.body.medium,
+      width: '100%',
+      padding: tokens.spacing[3],
+      border: `1px solid ${colors.outline}`,
+      borderRadius: tokens.borderRadius.small,
+      backgroundColor: colors.surface,
+      color: colors.onSurfaceVariant,
+      outline: 'none',
+      cursor: 'not-allowed',
+    },
+  });
+
+  const styles = getStyles();
+
+  const handleChange = (field: keyof QuestionBlockConfig, value: any) => {
+    onChange({
+      ...config,
+      [field]: value,
+    });
+  };
+
+  const handleConfigChange = (field: keyof DropdownInputConfig, value: any) => {
+    onChange({
+      ...config,
+      config: {
+        ...dropdownConfig,
+        [field]: value,
+      },
+    });
+  };
+
+  const handleAddOption = () => {
+    const newOption: MultipleChoiceOption = {
+      id: `option_${Date.now()}`,
+      title: 'New option',
+      body: '',
+    };
+    handleConfigChange('options', [...options, newOption]);
+  };
+
+  const handleUpdateOption = (index: number, field: keyof MultipleChoiceOption, value: string) => {
+    const updatedOptions = [...options];
+    updatedOptions[index] = {
+      ...updatedOptions[index],
+      [field]: value,
+    };
+    handleConfigChange('options', updatedOptions);
+  };
+
+  const handleDeleteOption = (index: number) => {
+    const updatedOptions = options.filter((_, i) => i !== index);
+    handleConfigChange('options', updatedOptions);
+  };
+
+  return (
+    <div style={styles.container}>
+      <div style={styles.header}>
+        <span
+          style={{
+            ...tokens.typography.label.large,
+            color: colors.primary,
+          }}
+        >
+          Dropdown Question
+        </span>
+      </div>
+
+      <div style={{ marginBottom: tokens.spacing[3] }}>
+        <label style={styles.label}>Question Title *</label>
+        <input
+          type="text"
+          value={config.title || ''}
+          onChange={(e) => handleChange('title', e.target.value)}
+          placeholder="Enter your question..."
+          style={styles.input}
+        />
+      </div>
+
+      <div style={{ marginBottom: tokens.spacing[3] }}>
+        <label style={styles.label}>Subtitle (optional)</label>
+        <input
+          type="text"
+          value={config.subtitle || ''}
+          onChange={(e) => handleChange('subtitle', e.target.value)}
+          placeholder="Additional context or instructions..."
+          style={styles.input}
+        />
+      </div>
+
+      <div style={{ marginBottom: tokens.spacing[3] }}>
+        <label style={styles.label}>Placeholder text</label>
+        <input
+          type="text"
+          value={placeholder}
+          onChange={(e) => handleConfigChange('placeholder', e.target.value)}
+          placeholder="Select an option..."
+          style={styles.input}
+        />
+      </div>
+
+      <div style={{ marginBottom: tokens.spacing[3] }}>
+        <label style={styles.label}>Dropdown Preview</label>
+        <select disabled style={styles.selectPreview} value="">
+          <option value="">{placeholder || 'Select an option...'}</option>
+          {options.map((option) => (
+            <option key={option.id} value={option.id}>
+              {option.title || 'Untitled option'}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div style={{ marginBottom: tokens.spacing[2] }}>
+        <label style={styles.label}>Options</label>
+      </div>
+
+      {options.map((option, index) => (
+        <div key={option.id} style={styles.optionRow}>
+          <span style={styles.optionIndex}>{index + 1}.</span>
+          <input
+            type="text"
+            value={option.title}
+            onChange={(e) => handleUpdateOption(index, 'title', e.target.value)}
+            placeholder="Option label"
+            style={styles.input}
+          />
+          <IconButton
+            icon="delete"
+            variant="text"
+            onClick={() => handleDeleteOption(index)}
+            title="Remove option"
+          />
+        </div>
+      ))}
+
+      <Button
+        variant="outlined"
+        onClick={handleAddOption}
+        style={{ marginTop: tokens.spacing[2] }}
+      >
+        + Add Option
+      </Button>
+
+      <div style={styles.checkbox}>
+        <input
+          type="checkbox"
+          id={`required-dropdown-${config.question_id}`}
+          checked={config.required || false}
+          onChange={(e) => handleChange('required', e.target.checked)}
+          style={styles.checkboxInput}
+        />
+        <label htmlFor={`required-dropdown-${config.question_id}`} style={styles.checkboxLabel}>
+          Required
+        </label>
+      </div>
+    </div>
+  );
+};

--- a/src/features/admin/components/index.ts
+++ b/src/features/admin/components/index.ts
@@ -13,4 +13,6 @@ export { EditableTextBlock } from './EditableTextBlock';
 export { EditableMediaBlock } from './EditableMediaBlock';
 export { EditableTextInputBlock } from './EditableTextInputBlock';
 export { EditableMultipleChoiceBlock } from './EditableMultipleChoiceBlock';
+export { EditableDropdownInputBlock } from './EditableDropdownInputBlock';
+export { EditableAorBInputBlock } from './EditableAorBInputBlock';
 export { EditableBlockRenderer } from './EditableBlockRenderer';

--- a/src/features/admin/utils/blockFactory.ts
+++ b/src/features/admin/utils/blockFactory.ts
@@ -51,6 +51,39 @@ export function createDefaultBlockConfig(blockType: string): Record<string, any>
         },
       };
 
+    case 'dropdown_input':
+      return {
+        question_id: `question_${Date.now()}`,
+        question_type: 'dropdown_input',
+        title: 'New Dropdown Question',
+        subtitle: '',
+        required: false,
+        config: {
+          placeholder: 'Select an option...',
+          options: [
+            { id: 'opt_1', title: 'Option 1', body: '' },
+            { id: 'opt_2', title: 'Option 2', body: '' },
+          ],
+        },
+      };
+
+    case 'a_or_b_input':
+      return {
+        question_id: `question_${Date.now()}`,
+        question_type: 'a_or_b_input',
+        title: 'New A or B Question',
+        subtitle: '',
+        required: false,
+        config: {
+          positive_label: 'Yes',
+          negative_label: 'No',
+          prompts: [
+            { id: 'prompt_1', title: 'First prompt', description: '' },
+            { id: 'prompt_2', title: 'Second prompt', description: '' },
+          ],
+        },
+      };
+
     default:
       return {};
   }
@@ -88,6 +121,8 @@ export function validateBlockConfig(block: BlockData): { valid: boolean; errors:
 
     case 'text_input':
     case 'multiple_choice':
+    case 'dropdown_input':
+    case 'a_or_b_input':
       if (!block.config.question_id) {
         errors.push('Question block must have question_id');
       }

--- a/src/features/admin/utils/blockTypes.ts
+++ b/src/features/admin/utils/blockTypes.ts
@@ -46,6 +46,20 @@ export const BLOCK_TYPES: Record<string, BlockTypeMetadata> = {
     category: 'question',
     description: 'Ask a multiple choice question',
   },
+  dropdown_input: {
+    type: 'dropdown_input',
+    icon: 'arrow_drop_down_circle',
+    label: 'Dropdown',
+    category: 'question',
+    description: 'Let respondents choose one option from a dropdown',
+  },
+  a_or_b_input: {
+    type: 'a_or_b_input',
+    icon: 'swap_horiz',
+    label: 'A or B',
+    category: 'question',
+    description: 'Step through prompts and capture yes/no decisions',
+  },
 };
 
 /**


### PR DESCRIPTION
## Summary
- add dedicated admin editors and registry entries for dropdown and A-or-B question blocks
- extend question rendering to support dropdown selections and animated sequential yes/no prompts
- update activity summaries and shared types so the new question configs round-trip correctly

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68ed63d7ac6c8330a916994449edfd9c